### PR TITLE
Change Debug.WriteLine to Console.WriteLine

### DIFF
--- a/nanoFramework.Logging/DebugLogger.cs
+++ b/nanoFramework.Logging/DebugLogger.cs
@@ -52,7 +52,8 @@ namespace nanoFramework.Logging.Debug
                     msg = (string)format.Invoke(null, new object[] { LoggerName, logLevel, eventId, state, exception });
                 }
 
-                Console.WriteLine(msg);  // nanoFramework.Core allows this library to use the internal System classes.  Console.WriteLog works when we build this library in both Debug and Release modes.
+                // need to use Console.WriteLine to have this working on both Debug and Release flavours
+                Console.WriteLine(msg); 
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please DO NOT use references to other PR's or issues -->
## Description
<!--- Describe your changes in detail -->
- Replace Debug.WriteLine with Console.WriteLine.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Fixes problem that DebugLogger wouldn't log when built with Release.  Console.WriteLine writes to the debug serial port for both Debug and Release builds.
- Resolves nanoFramework/Home#737.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
Tested using the test bench that is linked in the issue.  
<!--- Include details of your testing environment, and the tests you ran to -->
Built on VS2019 using the test bench.  Confirmed that DebugLogger output now shows in the Visual Studio Debug Output window.
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
