### PR TITLE
Fixing nuget reference for Logging.Serial

### DIFF
--- a/nanoFramework.Logging.Serial.nuspec
+++ b/nanoFramework.Logging.Serial.nuspec
@@ -26,8 +26,7 @@ There is also a package with the Stream Logging only and another with the basic 
       <dependency id="nanoFramework.CoreLibrary" version="1.10.5-alpha.145.6" />
       <dependency id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" />
       <dependency id="nanoFramework.System.Text" version="1.1.1-preview.51" />
-      <dependency id="nanoFramework.Windows.Devices.SerialCommunication" version="1.3.4-preview.94" />
-      <dependency id="nanoFramework.Windows.Storage.Streams" version="1.12.2-preview.5" />
+      <dependency id="nanoFramework.System.IO.Ports" version="1.0.0-preview.19" />
       <dependency id="nanoFramework.Logging" version="$version$" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
<!--- Provide a general, short summary of your changes in the Title above -->
<!--- Please DO NOT use references to other PR's or issues -->
## Description

Fixing nuget reference for Logging.Serial

## Motivation and Context

- Fixing nuget reference for Logging.Serial introduced when migrating to System.IO.Ports

## How Has This Been Tested?

With the tests. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
