### PR TITLE
Cache SerialPort in SerialLoggerFactory

### DIFF
--- a/nanoFramework.Logging.Serial/SerialLoggerFactory.cs
+++ b/nanoFramework.Logging.Serial/SerialLoggerFactory.cs
@@ -49,12 +49,15 @@ namespace nanoFramework.Logging.Serial
         /// <inheritdoc/>
         public ILogger CreateLogger(string categoryName)
         {
-            _serial = new SerialPort(_comPort);
-            _serial.BaudRate = _baudRate;
-            _serial.Parity = _parity;
-            _serial.StopBits = _stopBits;
-            _serial.Handshake = _handshake;
-            _serial.DataBits = _dataBits;
+            if (_serial is null)
+            {
+                _serial = new SerialPort(_comPort);
+                _serial.BaudRate = _baudRate;
+                _serial.Parity = _parity;
+                _serial.StopBits = _stopBits;
+                _serial.Handshake = _handshake;
+                _serial.DataBits = _dataBits;
+            }
             return new SerialLogger(ref _serial, categoryName);
         }
 


### PR DESCRIPTION
## Description
Only create SerialPort in SerialLoggerFactory if it wasn't already created.

## Motivation and Context
Avoid exception if SerialLoggerFactory.CreateLogger is called multiple times enabling multiple loggers on the same serial port.

## How Has This Been Tested?
N/A

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
